### PR TITLE
Fix /munijobs route crashing with ReferenceError on yearstring

### DIFF
--- a/routes/munijobs.js
+++ b/routes/munijobs.js
@@ -32,6 +32,7 @@ module.exports = function(app, pg, conString) {
 		//exit if no year
         if (!req.query.year) {
             res.send('please specify a year (or comma separated list of years)');
+            return;
         }
         //create array of muni fips codes
         var muni = (req.query.fips).split(",");
@@ -79,21 +80,13 @@ module.exports = function(app, pg, conString) {
             return;
         }
         //create sql selector for years
-        for (j = 0; j < year.length; j++) {
-            yearstring = yearstring + schtbl + " year = " + year[j] + " OR ";
-        }
-        //remove stray OR from end of sql selector
-        yearstring = yearstring.substring(0, yearstring.length - 3);
-
-
-        //create sql selector for years
-		var yearsting = ' year = ' + year[j];
+        var yearstring = ' year = ' + year[0];
         for (j = 1; j < year.length; j++) {
             yearstring = yearstring + " OR year = " + year[j];
         }
 
                 //put it all together
-        var sqlstring = basequery + ' WHERE ( ' + munistring + ') AND (' + yearstring + ');'
+        var sqlstring = basequery + '( ' + munistring + ') AND (' + yearstring + ');'
        
         sendtodatabase(sqlstring, pg, conString, res);
     });


### PR DESCRIPTION
The /munijobs route throws a ReferenceError because yearstring is used before it's ever declared, so any valid request crashes the handler and returns a 500 instead of hitting the database. This rebuilds the year selector the same way the muni selector right above it is built (declare it with the first year, then OR in the rest), drops a duplicate WHERE that basequery already adds, and adds the missing return on the no-year branch so it stops falling through into the crash.

I verified it by registering the handler with a stubbed pg client and capturing the query: before the change fips=760&year=2010 throws "yearstring is not defined", and after it produces well-formed SQL matching the working /jobs route. Thanks for taking a look.
